### PR TITLE
find the right pid

### DIFF
--- a/reSnap.sh
+++ b/reSnap.sh
@@ -94,8 +94,14 @@ elif [ "$rm_version" = "reMarkable 2.0" ]; then
 
   window_bytes="$((width * height * bytes_per_pixel))"
 
-  # find xochitl's process
-  pid="$(ssh_cmd pidof xochitl)"
+  # Find xochitl's process. In case of more than one pids, take the first one which contains /dev/fb0.
+  for n in $(ssh_cmd pidof xochitl); do
+    pid=$n
+    has_fb=$(ssh_cmd "grep -C1 '/dev/fb0' /proc/$pid/maps")
+    if [ "$has_fb" != "" ]; then
+      break
+    fi
+  done
 
   # find framebuffer location in memory
   # it is actually the map allocated _after_ the fb0 mmap


### PR DESCRIPTION
`pidof xochitl` returned two pids for me, breaking the grep line which follows. (The other pid could be perhaps because I am also running the remux launcher.)

In my case only one of the /proc/pid/maps contained the /dev/fb0, so I added a loop to check which one is right.