### PR TITLE
remove requirement for 'head', as 'cut' is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ reMarkable screenshots over ssh.
 
 - The following programs are required on your reMarkable:
   - `lz4`
-  - `head` (only reMarkable 2.0)
 
 - The following programs are required on your computer:
   - `lz4`
@@ -24,11 +23,10 @@ reMarkable screenshots over ssh.
 
 ### Installing Programs on your reMarkable
 
-Please use [toltec](https://github.com/toltec-dev/toltec) to install `lz4` and `head` on your reMarkable.
+Please use [toltec](https://github.com/toltec-dev/toltec) to install `lz4` on your reMarkable.
 
 Packages:
 - `lz4`
-- `coreutils-head`
 
 Note: before installing the packages, run
 ```

--- a/reSnap.sh
+++ b/reSnap.sh
@@ -126,21 +126,11 @@ elif [ "$rm_version" = "reMarkable 2.0" ]; then
   window_offset="$((skip_bytes % page_size))"
   window_length_blocks="$((window_bytes / page_size + 1))"
 
-  # find head
-  if ssh_cmd "[ -f /opt/bin/head ]"; then
-    head="/opt/bin/head"
-  elif ssh_cmd "[ -f ~/head ]"; then # backwards compatibility
-    head="\$HOME/head"
-  else
-    echo "head not found on $rm_version. Please refer to the README"
-    exit 2
-  fi
-
   # Using dd with bs=1 is too slow, so we first carve out the pages our desired
   # bytes are located in, and then we trim the resulting data with what we need.
   head_fb0="dd if=/proc/$pid/mem bs=$page_size skip=$window_start_blocks count=$window_length_blocks 2>/dev/null |
     tail -c+$window_offset |
-    $head -c $window_bytes"
+    cut -b -$window_bytes"
 
   # pixel format
   pixel_format="gray8"


### PR DESCRIPTION
On Remarkable2, v2.14.3.977, `cut` is available, and can be used as `cut -b -${last_byte}`... this removes the need for `head` to be installed.

Please could someone confirm if this is true for previous versions too?