### PR TITLE
add byte correction for rm >= 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ reMarkable screenshots over ssh.
 - `-d --display` Force program to display the snapshot. (overwrites environment variable)
 - `-n --no-display` Force program to not display the snapshot.
 - `-c --og-color` Turn off color correction (color correction is only active for the reMarkable2)
+- `-d --og-pixel-format` Turns off the byte correction (use this if your reMarkable is on version < 3.6)
 - `-v --version` Displays version.
 - `-h --help` Displays help information.
 
@@ -43,8 +44,9 @@ reMarkable screenshots over ssh.
 - `REMARKABLE_IP` Default IP of your reMarkable.
 - `RESNAP_DISPLAY` Default behavior of displaying the snapshot. See options `-d` and `-n`.
 - `RESNAP_COLOR_CORRECTION` Default behavior of color correction on the reMarkable2. See option `-c`.
+- `RESNAP_BYTE_CORRECTION` Default behavior of color correction on the reMarkable2 version >= 3.6. See option `-b`.
 
-`RESNAP_DISPLAY` and `RESNAP_COLOR_CORRECTION` are boolean parameters.
+`RESNAP_DISPLAY`, `RESNAP_COLOR_CORRECTION` and `RESNAP_BYTE_CORRECTION` are boolean parameters.
 Everything other than `true` is interpreted as `false`!
 
 ## Recommended for better performance

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ reMarkable screenshots over ssh.
 - `-d --display` Force program to display the snapshot. (overwrites environment variable)
 - `-n --no-display` Force program to not display the snapshot.
 - `-c --og-color` Turn off color correction (color correction is only active for the reMarkable2)
-- `-d --og-pixel-format` Turns off the byte correction (use this if your reMarkable is on version < 3.6)
+- `-p --og-pixel-format` Turns off the byte correction (use this if your reMarkable is on version < 3.6)
 - `-v --version` Displays version.
 - `-h --help` Displays help information.
 

--- a/reSnap.sh
+++ b/reSnap.sh
@@ -46,7 +46,7 @@ while [ $# -gt 0 ]; do
   -c | --og-color)
     color_correction="false"
     shift
-  -b | -og-pixel-format
+  -p | --og-pixel-format
     byte="false"
     col
     ;;
@@ -64,7 +64,7 @@ while [ $# -gt 0 ]; do
     echo "  $0 -d                 # display the file"
     echo "  $0 -n                 # don't display the file"
     echo "  $0 -c                 # no color correction (reMarkable2)"
-    echo "  $0 -b                 # no byte correction (reMarkable2 version < 3.6)"
+    echo "  $0 -p                 # no pixel format correction (reMarkable2 version < 3.6)"
     echo "  $0 -v                 # displays version"
     echo "  $0 -h                 # displays help information (this)"
     exit 2


### PR DESCRIPTION
Since the remarkable 3.6 version the screenshots are corrupted, this PR fixes this using a variation of the solution proposed in [reStream #95](https://github.com/rien/reStream/issues/95). 

I also added a `-p` or `--og-pixel-format` parameter to restore the previous behaviour.