### PR TITLE
Add Nix Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ reMarkable screenshots over ssh.
 ./reSnap.sh
 ```
 
+Or, if you have `nix` installed, you can just run
+```
+nix run github:cloudsftp/reSnap
+```
+To automatically get the dependencies and then run the script
+
 ### Options
 
 - `-s --source` You can specify a custom IP. If you want to use reSnap over the Wifi, specify the IP of your reMarkable here.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+{
+  pkgs ? import <nixpkgs> {},
+  writeShellApplication,
+  ...
+}:
+writeShellApplication {
+  name = "reSnap";
+  runtimeInputs = with pkgs; [
+    ffmpeg
+    feh
+    imagemagick_light
+    lz4
+  ];
+  text = builtins.readFile ./reSnap.sh;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Take screnshots of your reMarkable tablet over SSH";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: (
+        let
+          pkgs = import nixpkgs {inherit system;};
+          reSnap = pkgs.callPackage ./. {};
+        in {
+          packages = rec {
+            inherit reSnap;
+            default = reSnap;
+          };
+          apps = {
+            reSnap = flake-utils.lib.mkApp {
+              name = "reSnap";
+              drv = reSnap;
+            };
+          };
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs; [
+              ffmpeg
+              feh
+              imagemagick_light
+              lz4
+            ];
+          };
+        }
+      )
+    );
+}

--- a/reSnap.sh
+++ b/reSnap.sh
@@ -161,12 +161,19 @@ elif [ "$rm_version" = "reMarkable 2.0" ]; then
   # it is actually the map allocated _after_ the fb0 mmap
   read_address="grep -C1 '/dev/fb0' /proc/$pid/maps | tail -n1 | sed 's/-.*$//'"
   skip_bytes_hex="$(ssh_cmd "$read_address")"
-  skip_bytes="$((0x$skip_bytes_hex + 7))"
+  skip_bytes="$((0x$skip_bytes_hex + 8))"
 
-  # remarkable's dd does not have iflag=skip_bytes, so cut the command in two:
-  # one to seek the exact amount and the second to copy in a large chunk
+  # carve the framebuffer out of the process memory
+  page_size=4096
+  window_start_blocks="$((skip_bytes / page_size))"
+  window_offset="$((skip_bytes % page_size))"
+  window_length_blocks="$((window_bytes / page_size + 1))"
+
+  # Using dd with bs=1 is too slow, so we first carve out the pages our desired
   # bytes are located in, and then we trim the resulting data with what we need.
-  head_fb0="{ dd bs=1 skip=$skip_bytes count=0 && dd bs=$window_bytes count=1; } < /proc/$pid/mem 2>/dev/null"
+  head_fb0="dd if=/proc/$pid/mem bs=$page_size skip=$window_start_blocks count=$window_length_blocks 2>/dev/null |
+    tail -c+$window_offset |
+    cut -b -$window_bytes"
 
   # color correction
   if [ "$color_correction" = "true" ]; then


### PR DESCRIPTION
TLDR: If you have nix, now you'll be able to just do `nix run github:cloudsftp/reSnap` to run the script with all dependencies automatically fetched and "baked" into it.

I added a basic nix flake and package that includes `feh`, `ffmpeg`, `lz4`, and `imagemagick`. It's pretty simple but makes it easier to use for anyone who has nix installed.